### PR TITLE
Reading BASE_DIR from env

### DIFF
--- a/DOS/cfdiengine/service/dmcli.py
+++ b/DOS/cfdiengine/service/dmcli.py
@@ -57,8 +57,8 @@ def dmcli(args, logger):
     logging.basicConfig(level=logging.DEBUG if args.dm_debug else logging.INFO)
     logger.debug(args)
 
-    DEFAULT_RESDIR = '{}/resources'.format(os.environ['ERP_ROOT'])
-    DEFAULT_PROFILE = 'default.json'
+    DEFAULT_RESDIR = os.path.join(os.environ['BASE_DIR'], 'resources')
+    DEFAULT_PROFILE = 'cfdiengine.json'
 
     resdir = args.resdir if args.resdir else DEFAULT_RESDIR
     profiles_dir = '{}/profiles'.format(resdir)


### PR DESCRIPTION
en container:

python dmcli.py -d -o 2_MILL2620.pdf -b facpdf -i "rfc=DMM090223SF9;xml=2_MILL2620.xml"

las comillas fueron necesarias en el caso de -i, supongo por el ';' que es usado por el shell. Al final movi el pdf a la ruta adecuada